### PR TITLE
Fully implement v1 feature

### DIFF
--- a/exhaustive.go
+++ b/exhaustive.go
@@ -277,5 +277,10 @@ func run(pass *analysis.Pass) (interface{}, error) {
 		checkGeneratedFiles:        fCheckGenerated,
 		ignoreEnumMembers:          fIgnoreEnumMembers.value(),
 	})
+
+	checkStructLiterals(pass, inspect, structConfig{
+		checkGeneratedFiles: fCheckGenerated,
+	})
+
 	return nil, nil
 }

--- a/struct.go
+++ b/struct.go
@@ -1,48 +1,21 @@
-
 package exhaustive
 
 import (
 	"fmt"
 	"go/ast"
 	"go/types"
-	"regexp"
 	"sort"
 	"strings"
 
 	"golang.org/x/tools/go/analysis"
-	"golang.org/x/tools/go/ast/astutil"
 	"golang.org/x/tools/go/ast/inspector"
 )
 
-// nodeVisitor is like the visitor function used by Inspector.WithStack,
-// except that it returns an additional value: a short description of
-// the result of this node visit.
-//
-// The result is typically useful in debugging or in unit tests to check
-// that the nodeVisitor function took the expected code path.
-type nodeVisitor func(n ast.Node, push bool, stack []ast.Node) (proceed bool, result string)
-
-// Result values returned by a node visitor constructed via switchStmtChecker.
-const (
-	resultNotPush                = "not push"
-	resultGeneratedFile          = "generated file"
-	resultNoSwitchTag            = "no switch tag"
-	resultTagNotValue            = "switch tag not value type"
-	resultTagNotNamed            = "switch tag not named type"
-	resultTagNoPkg               = "switch tag does not belong to regular package"
-	resultTagNotEnum             = "switch tag not known enum type"
-	resultSwitchIgnoreComment    = "switch statement has ignore comment"
-	resultSwitchNoEnforceComment = "switch statement has no enforce comment"
-	resultEnumMembersAccounted   = "requisite enum members accounted for"
-	resultDefaultCaseSuffices    = "default case presence satisfies exhaustiveness"
-	resultReportedDiagnostic     = "reported diagnostic"
-)
-
-// structLitChecker returns a node visitor that checks exhaustiveness
-// of struct literal statements for the supplied pass, and reports diagnostics for
-// structs literal statements that are non-exhaustive.
-// It expects to only see *ast.CompositeLit nodes.
-func structLitChecker(pass *analysis.Pass, cfg config) nodeVisitor {
+// structLiteralChecker returns a node visitor that checks exhaustiveness
+// of struct literal statements for the supplied pass, and reports diagnostics
+// for structs literal statements that are non-exhaustive. It expects to only
+// see *ast.CompositeLit nodes.
+func structLiteralChecker(pass *analysis.Pass, cfg structConfig) nodeVisitor {
 	generated := make(map[*ast.File]bool)          // cached results
 	comments := make(map[*ast.File]ast.CommentMap) // cached results
 
@@ -69,274 +42,186 @@ func structLitChecker(pass *analysis.Pass, cfg config) nodeVisitor {
 
 		structLiteral := n.(*ast.CompositeLit)
 
+		typeInfo := pass.TypesInfo.Types[structLiteral]
+		structTypeName, structType, ok := resolveStructType(typeInfo.Type)
+		if !ok {
+			return true, resultCompositeLitNotAStruct
+		}
+
 		if _, ok := comments[file]; !ok {
 			comments[file] = ast.NewCommentMap(pass.Fset, file, file.Comments)
 		}
 		structComments := comments[file][structLiteral]
 		if !containsEnforceDirective(structComments) {
-			// Skip checking of this switch statement due to missing enforce directive comment.
-			return true, resultSwitchNoEnforceComment
+			// Skip checking of this struct literal due to missing enforce directive comment.
+			return true, resultStructNoEnforceComment
 		}
 
-		typeInfo := pass.TypesInfo.Types[structLiteral.Type]
-		if !typeInfo.IsType() {
-			return true, resultTagNotValue
-		}
-
-
-		structType, ok := typeInfo.Type.(*types.Struct)
-		if !ok {
-			return true, resultTagNotNamed
-		}
-
-		structFields := []string{}
-		for i:= 0; i<structType.NumFields(); i++ {
+		structFields := make([]string, 0, structType.NumFields())
+		for i := 0; i < structType.NumFields(); i++ {
 			structFields = append(structFields, structType.Field(i).Name())
 		}
 
-
-		samePkg := tagPkg == pass.Pkg // do the switch statement and the switch tag type (i.e. enum type) live in the same package?
-		checkUnexported := samePkg    // we want to include unexported members in the exhaustiveness check only if we're in the same package
-		checklist := makeChecklist(members, tagPkg, checkUnexported, cfg.ignoreEnumMembers)
-
-		hasDefaultCase := analyzeSwitchClauses(structLiteral, pass.TypesInfo, func(val constantValue) {
-			checklist.found(val)
-		})
+		// do struct literal and struct definition live in the same package?
+		samePkg := true
+		if structTypeName != nil {
+			structPkg := structTypeName.Pkg()
+			samePkg = structPkg == pass.Pkg
+		}
+		// we want to include unexported fields in the exhaustiveness check only if we're in the same package
+		checkUnexported := samePkg
+		checklist := makeStructChecklist(structFields, checkUnexported)
+		isUnkeyedLit := analyzeStructLiteralFields(structLiteral, checklist.found)
+		if isUnkeyedLit {
+			return true, resultStructUnkeyedLiteral
+		}
 
 		if len(checklist.remaining()) == 0 {
-			// All enum members accounted for.
+			// All struct fields accounted for.
 			// Nothing to report.
-			return true, resultEnumMembersAccounted
+			return true, resultStructFieldsAccounted
 		}
-		if hasDefaultCase && cfg.defaultSignifiesExhaustive {
-			// Though enum members are not accounted for,
-			// the existence of the default case signifies exhaustiveness.
-			// So don't report.
-			return true, resultDefaultCaseSuffices
-		}
-		pass.Report(makeDiagnostic(structLiteral, samePkg, enumTyp, members, checklist.remaining()))
+		pass.Report(makeStructDiagnostic(structLiteral, samePkg, structTypeName, checklist.remaining()))
 		return true, resultReportedDiagnostic
 	}
 }
 
-// config is configuration for checkSwitchStatements.
-type config struct {
-	explicitExhaustiveSwitch   bool
-	defaultSignifiesExhaustive bool
-	checkGeneratedFiles        bool
-	ignoreEnumMembers          *regexp.Regexp // can be nil
+// structConfig is a configuration for checkStructLiterals.
+type structConfig struct {
+	checkGeneratedFiles bool
 }
 
-// checkSwitchStatements checks exhaustiveness of enum switch statements for the supplied
-// pass. It reports switch statements that are not exhaustive via pass.Report.
-func checkSwitchStatements(pass *analysis.Pass, inspect *inspector.Inspector, cfg config) {
-	f := switchStmtChecker(pass, cfg)
+// resolveStructType resolves the struct type of the composite literal if it
+// is a struct and the struct type name if the struct is not anonymous. If the
+// struct is type aliased, this method will identify the bottom-level
+// unwrapped struct type and type name
+func resolveStructType(compositeLiteralType types.Type) (_ *types.TypeName, _ *types.Struct, isStruct bool) {
+	t := compositeLiteralType
+	i := 0
+	for {
+		i += 1
+		switch v := t.(type) {
+		case *types.Pointer:
+			t = v.Elem()
+		case *types.Struct:
+			return nil, v, true
+		case *types.Named:
+			underlying := v.Underlying()
+			if structType, ok := underlying.(*types.Struct); ok {
+				return v.Obj(), structType, true
+			}
+			t = underlying
+		default:
+			return nil, nil, false
+		}
+	}
+}
 
-	inspect.WithStack([]ast.Node{&ast.SwitchStmt{}}, func(n ast.Node, push bool, stack []ast.Node) bool {
+// checkStructLiterals checks exhaustiveness of struct literal fields for the
+// supplied pass. It reports struct literals that are not exhaustive via
+// pass.Report.
+func checkStructLiterals(pass *analysis.Pass, inspect *inspector.Inspector, cfg structConfig) {
+	f := structLiteralChecker(pass, cfg)
+
+	inspect.WithStack([]ast.Node{&ast.CompositeLit{}}, func(n ast.Node, push bool, stack []ast.Node) bool {
 		proceed, _ := f(n, push, stack)
 		return proceed
 	})
 }
 
-func isDefaultCase(c *ast.CaseClause) bool {
-	return c.List == nil // see doc comment on List field
-}
-
-func denotesPackage(ident *ast.Ident, info *types.Info) (*types.Package, bool) {
-	obj := info.ObjectOf(ident)
-	if obj == nil {
-		return nil, false
-	}
-	n, ok := obj.(*types.PkgName)
-	if !ok {
-		return nil, false
-	}
-	return n.Imported(), true
-}
-
-// analyzeSwitchClauses analyzes the clauses in the supplied switch statement.
-// The info param should typically be pass.TypesInfo. The found function is
-// called for each enum member name found in the switch statement.
-// The hasDefaultCase return value indicates whether the switch statement has a
-// default clause.
-func analyzeSwitchClauses(sw *ast.SwitchStmt, info *types.Info, found func(val constantValue)) (hasDefaultCase bool) {
-	for _, stmt := range sw.Body.List {
-		caseCl := stmt.(*ast.CaseClause)
-		if isDefaultCase(caseCl) {
-			hasDefaultCase = true
-			continue // nothing more to do if it's the default case
-		}
-		for _, expr := range caseCl.List {
-			analyzeCaseClauseExpr(expr, info, found)
-		}
-	}
-	return hasDefaultCase
-}
-
-func analyzeCaseClauseExpr(e ast.Expr, info *types.Info, found func(val constantValue)) {
-	handleIdent := func(ident *ast.Ident) {
-		obj := info.Uses[ident]
-		if obj == nil {
-			return
-		}
-		if _, ok := obj.(*types.Const); !ok {
-			return
-		}
-
-		// There are two scenarios.
-		// See related test cases in typealias/quux/quux.go.
-		//
-		// ### Scenario 1
-		//
-		// Tag package and constant package are the same.
-		//
-		// For example:
-		//   var mode fs.FileMode
-		//   switch mode {
-		//   case fs.ModeDir:
-		//   }
-		//
-		// This is simple: we just use fs.ModeDir's value.
-		//
-		// ### Scenario 2
-		//
-		// Tag package and constant package are different.
-		//
-		// For example:
-		//   var mode fs.FileMode
-		//   switch mode {
-		//   case os.ModeDir:
-		//   }
-		//
-		// Or equivalently:
-		//   var mode os.FileMode // in effect, fs.FileMode because of type alias in package os
-		//   switch mode {
-		//   case os.ModeDir:
-		//   }
-		//
-		// In this scenario, too, we accept the case clause expr constant
-		// value, as is. If the Go type checker is okay with the
-		// name being listed in the case clause, we don't care much further.
-		//
-		found(determineConstVal(ident, info))
-	}
-
-	e = astutil.Unparen(e)
-	switch e := e.(type) {
-	case *ast.Ident:
-		handleIdent(e)
-
-	case *ast.SelectorExpr:
-		x := astutil.Unparen(e.X)
-		// Ensure we only see the form `pkg.Const`, and not e.g. `structVal.f`
-		// or `structVal.inner.f`.
-		// Check that X, which is everything except the rightmost *ast.Ident (or
-		// Sel), is also an *ast.Ident.
-		xIdent, ok := x.(*ast.Ident)
+// analyzeStructLiteralFields analyzers the strings in the supplied struct
+// literal. The found function is called for each field found in the struct
+// literal.
+// The isUnkeyedLiteral return value indicates whether the struct literal only
+// has unkeyed fields, in which case the analyzer has nothing to do.
+func analyzeStructLiteralFields(structLiteral *ast.CompositeLit, found func(fieldName string)) (isUnkeyedLiteral bool) {
+	for _, elem := range structLiteral.Elts {
+		keyValueElt, ok := elem.(*ast.KeyValueExpr)
 		if !ok {
-			return
+			return true
 		}
-		// Doesn't matter which package, just that it denotes a package.
-		if _, ok := denotesPackage(xIdent, info); !ok {
-			return
+		if keyValueElt.Key == nil {
+			return true
 		}
-		handleIdent(e.Sel)
+		found(keyValueElt.Key.(*ast.Ident).Name)
 	}
+	return false
 }
 
-// diagnosticMissingMembers constructs the list of missing enum members,
-// suitable for use in a reported diagnostic message.
-func diagnosticMissingMembers(missingMembers map[string]struct{}, em enumMembers) []string {
-	missingByConstVal := make(map[constantValue][]string) // missing members, keyed by constant value.
-	for m := range missingMembers {
-		val := em.NameToValue[m]
-		missingByConstVal[val] = append(missingByConstVal[val], m)
-	}
-
-	var out []string
-	for _, names := range missingByConstVal {
-		sort.Strings(names)
-		out = append(out, strings.Join(names, "|"))
-	}
-	sort.Strings(out)
-	return out
-}
-
-// diagnosticEnumTypeName returns a string representation of an enum type for
+// diagnosticStructTypeName returns a string representation of a struct type for
 // use in reported diagnostics.
-func diagnosticEnumTypeName(enumType *types.TypeName, samePkg bool) string {
-	if samePkg {
-		return enumType.Name()
+func diagnosticStructTypeName(structTyp *types.TypeName, samePkg bool) string {
+	if structTyp == nil {
+		return "(anonymous)"
 	}
-	return enumType.Pkg().Name() + "." + enumType.Name()
+	if samePkg {
+		return structTyp.Name()
+	}
+	return structTyp.Pkg().Name() + "." + structTyp.Name()
 }
 
-// Makes a "missing cases in switch" diagnostic.
-// samePkg should be true if the enum type and the switch statement are defined
-// in the same package.
-func makeDiagnostic(sw *ast.SwitchStmt, samePkg bool, enumTyp enumType, allMembers enumMembers, missingMembers map[string]struct{}) analysis.Diagnostic {
-	message := fmt.Sprintf("missing cases in switch of type %s: %s",
-		diagnosticEnumTypeName(enumTyp.TypeName, samePkg),
-		strings.Join(diagnosticMissingMembers(missingMembers, allMembers), ", "))
+// A checklist holds a set of struct field names that have to be accounted
+// for to satisfy exhaustiveness in a struct literal. The found method checks
+// off struct fields from the set, based on constant value, when a struct
+// field is encoutered in the struct literal.
+//
+// The remaining method returns the member names not accounted for.
+type structChecklist struct {
+	checkl map[string]struct{}
+}
+
+// Makes a "missing fields in struct" diagnostic.
+// samePkg should be true if the struct definition and the struct literal are
+// defined in the same package.
+func makeStructDiagnostic(
+	cl *ast.CompositeLit, samePkg bool, structTyp *types.TypeName,
+	missingFields map[string]struct{},
+) analysis.Diagnostic {
+	var missingFieldArray []string
+	for elem := range missingFields {
+		missingFieldArray = append(missingFieldArray, elem)
+	}
+	sort.Strings(missingFieldArray)
+	message := fmt.Sprintf("missing fields in struct of type %s: %s",
+		diagnosticStructTypeName(structTyp, samePkg),
+		strings.Join(missingFieldArray, ", "))
 
 	return analysis.Diagnostic{
-		Pos:     sw.Pos(),
-		End:     sw.End(),
+		Pos:     cl.Pos(),
+		End:     cl.End(),
 		Message: message,
 	}
 }
 
-// A checklist holds a set of enum member names that have to be
-// accounted for to satisfy exhaustiveness in an enum switch statement.
-//
-// The found method checks off member names from the set, based on
-// constant value, when a constant value is encoutered in the switch
-// statement's cases.
-//
-// The remaining method returns the member names not accounted for.
-//
-type checklist struct {
-	em     enumMembers
-	checkl map[string]struct{}
-}
-
-func makeChecklist(em enumMembers, enumPkg *types.Package, includeUnexported bool, ignore *regexp.Regexp) *checklist {
+func makeStructChecklist(fieldNames []string, includeUnexported bool) *structChecklist {
 	checkl := make(map[string]struct{})
 
 	add := func(memberName string) {
 		if memberName == "_" {
-			// Blank identifier is often used to skip entries in iota lists.
-			// Also, it can't be referenced anywhere (including in a switch
-			// statement's cases), so it doesn't make sense to include it
-			// as required member to satisfy exhaustiveness.
+			// Blank field is effectively a directive to disallow "list-type" struct
+			// initialization, but it can never be set
 			return
 		}
 		if !ast.IsExported(memberName) && !includeUnexported {
 			return
 		}
-		if ignore != nil && ignore.MatchString(enumPkg.Path()+"."+memberName) {
-			return
-		}
 		checkl[memberName] = struct{}{}
 	}
 
-	for _, name := range em.Names {
+	for _, name := range fieldNames {
 		add(name)
 	}
 
-	return &checklist{
-		em:     em,
+	return &structChecklist{
 		checkl: checkl,
 	}
 }
 
-func (c *checklist) found(val constantValue) {
+func (c *structChecklist) found(fieldName string) {
 	// Delete all of the same-valued names.
-	for _, name := range c.em.ValueToNames[val] {
-		delete(c.checkl, name)
-	}
+	delete(c.checkl, fieldName)
 }
 
-func (c *checklist) remaining() map[string]struct{} {
+func (c *structChecklist) remaining() map[string]struct{} {
 	return c.checkl
 }

--- a/struct.go
+++ b/struct.go
@@ -97,9 +97,7 @@ type structConfig struct {
 // unwrapped struct type and type name
 func resolveStructType(compositeLiteralType types.Type) (_ *types.TypeName, _ *types.Struct, isStruct bool) {
 	t := compositeLiteralType
-	i := 0
 	for {
-		i += 1
 		switch v := t.(type) {
 		case *types.Pointer:
 			t = v.Elem()

--- a/struct.go
+++ b/struct.go
@@ -127,7 +127,7 @@ func checkStructLiterals(pass *analysis.Pass, inspect *inspector.Inspector, cfg 
 	})
 }
 
-// analyzeStructLiteralFields analyzers the strings in the supplied struct
+// analyzeStructLiteralFields analyzes the fields in the supplied struct
 // literal. The found function is called for each field found in the struct
 // literal.
 // The isUnkeyedLiteral return value indicates whether the struct literal only

--- a/switch_test.go
+++ b/switch_test.go
@@ -110,7 +110,7 @@ func TestMakeDiagnostic(t *testing.T) {
 	checkEnumMembersLiteral("Biome", allMembers)
 	missingMembers := map[string]struct{}{"Savanna": {}, "Desert": {}}
 
-	got := makeDiagnostic(sw, samePkg, enumTyp, allMembers, missingMembers)
+	got := makeSwitchDiagnostic(sw, samePkg, enumTyp, allMembers, missingMembers)
 	want := analysis.Diagnostic{
 		Pos:     1,
 		End:     11,
@@ -233,7 +233,7 @@ func TestChecklist(t *testing.T) {
 	}
 
 	t.Run("main operations", func(t *testing.T) {
-		checklist := makeChecklist(em, enumPkg, false, nil)
+		checklist := makeSwitchChecklist(em, enumPkg, false, nil)
 		checkRemaining(t, checklist, map[string]struct{}{
 			"A": {},
 			"B": {},
@@ -297,7 +297,7 @@ func TestChecklist(t *testing.T) {
 
 	t.Run("ignore regexp", func(t *testing.T) {
 		t.Run("nil means no filtering", func(t *testing.T) {
-			checklist := makeChecklist(em, enumPkg, false, nil)
+			checklist := makeSwitchChecklist(em, enumPkg, false, nil)
 			checkRemaining(t, checklist, map[string]struct{}{
 				"A": {},
 				"B": {},
@@ -310,7 +310,7 @@ func TestChecklist(t *testing.T) {
 		})
 
 		t.Run("basic", func(t *testing.T) {
-			checklist := makeChecklist(em, enumPkg, false, regexp.MustCompile(`^github.com/example/bar-go.G$`))
+			checklist := makeSwitchChecklist(em, enumPkg, false, regexp.MustCompile(`^github.com/example/bar-go.G$`))
 			checkRemaining(t, checklist, map[string]struct{}{
 				"A": {},
 				"B": {},
@@ -322,12 +322,12 @@ func TestChecklist(t *testing.T) {
 		})
 
 		t.Run("matches multiple", func(t *testing.T) {
-			checklist := makeChecklist(em, enumPkg, false, regexp.MustCompile(`^github.com/example/bar-go`))
+			checklist := makeSwitchChecklist(em, enumPkg, false, regexp.MustCompile(`^github.com/example/bar-go`))
 			checkRemaining(t, checklist, map[string]struct{}{})
 		})
 
 		t.Run("uses package path, not package name", func(t *testing.T) {
-			checklist := makeChecklist(em, enumPkg, false, regexp.MustCompile(`bar.G`))
+			checklist := makeSwitchChecklist(em, enumPkg, false, regexp.MustCompile(`bar.G`))
 			checkRemaining(t, checklist, map[string]struct{}{
 				"A": {},
 				"B": {},
@@ -364,7 +364,7 @@ func TestChecklist(t *testing.T) {
 		}
 		checkEnumMembersLiteral("TestChecklist blank identifier", em)
 
-		checklist := makeChecklist(em, enumPkg, true, nil)
+		checklist := makeSwitchChecklist(em, enumPkg, true, nil)
 		checkRemaining(t, checklist, map[string]struct{}{
 			"A": {},
 			"B": {},
@@ -401,7 +401,7 @@ func TestChecklist(t *testing.T) {
 		checkEnumMembersLiteral("TestChecklist lowercase", em)
 
 		t.Run("include", func(t *testing.T) {
-			checklist := makeChecklist(em, enumPkg, true, nil)
+			checklist := makeSwitchChecklist(em, enumPkg, true, nil)
 			checkRemaining(t, checklist, map[string]struct{}{
 				"A":         {},
 				"B":         {},
@@ -415,7 +415,7 @@ func TestChecklist(t *testing.T) {
 		})
 
 		t.Run("don't include", func(t *testing.T) {
-			checklist := makeChecklist(em, enumPkg, false, nil)
+			checklist := makeSwitchChecklist(em, enumPkg, false, nil)
 			checkRemaining(t, checklist, map[string]struct{}{
 				"A": {},
 				"B": {},


### PR DESCRIPTION
Rename various methods appropriately to be specific to switch statements and struct literals. Implement correct logic
for extracting composite literal type name, package name, and fields in order to perform exhaustiveness enforcement.